### PR TITLE
baip-0002.md

### DIFF
--- a/baip-0002.md
+++ b/baip-0002.md
@@ -1,0 +1,62 @@
+    BAIP: 0002
+    Title: Reform of loopholes in feed price mechanism
+    Authors: cn-vote  bitshareschina@163.com
+    Status: Draft
+    Type: Consensus 
+    Created: 2019-10-22
+
+
+# Abstract
+This BAIP defines reforms to the current feed price mechanism vulnerability. The specific program is: The` feed price` is the highest between the `current price` and the ` two-day moving average price` .
+# Motivation
+After the failure of [BSIP42](https://github.com/bitshares/bsips/blob/master/bsip-0042.md), the current feed price mechanism has major loopholes and serious negatives, many cex exchanges use our vulnerability to maliciously short,which seriously damaged the ecological balance, which caused us to suffer many unnecessary losses and hindered the development of the entire ecology.
+When the vulnerability has been expanded to be intolerable, in an emergency, the passage and execution of [BSIP76](https://github.com/bitshares/bsips/blob/master/bsip-0076.md) has temporarily blocked the expansion of the vulnerability. However, the current feed price mechanism is still in urgent need of reform.
+# Rational
+"The feed price is the highest between the ` current price` and the `two-day moving average price` ".
+This BAIP does not conflict with the previous consensus on the feed price of all the communities. The feed provider continue to collect the feed price according to the original community consensus, and the community consensus on the protection of the black swan([BSIP58](https://github.com/bitshares/bsips/blob/master/bsip-0058.md)) and the minimum feed price is continued([BSIP76](https://github.com/bitshares/bsips/blob/master/bsip-0076.md)).
+ This BAIP only requires the introduction of the abstract described in the feed price script, which is 
+ "The feed price is the highest between the ` current price`  and the ` two-day moving average price` ".
+# Specifications
+## Implementing measures
+```c
+If (current price >  two-day moving average price) {
+  feed price = current price;
+}
+Else{
+  feed price = two-day moving average price;
+}
+```
+
+
+## Noun explanation
+* ` Current price ` : The real-time feed price of the current feed price mechanism before the reform.
+* ` Two-day moving average price` : ` two-day moving average price`  =(` current price (1)`  + ` current price (2)`  + ` current price ( 3)` ...+` current 
+      price (n)` )/n.
+    *  n is the `sampling frequency`, which is 48 times, that is, n = 48*m; m is positive: m = 1, 2, 3....
+    * `current price (k)` is the current price at the time of sampling. The ` current price (1) ` is the 
+        current price at this moment. The ` current price (n) ` is the current price at the time of 48 hours  ago.
+    * `Sampling interval` (in hours): `sampling interval` = 48 / n = 48 / (48 * m). That is: m = 1, ` two- 
+      day moving average price` every hour to sample once,;m = 2, ` two-day moving average price` half an hour to sample once, And so on.
+## supplementary explanation
+To decide whether to reform of loopholes in feed price mechanism, 2 poll worker proposals will be created for voting:
+* Poll-BAIP**- Reform of loopholes in feed price mechanism.
+* Poll-BAIP**-Not reform of loopholes in feed price mechanism.
+
+If the voting confirm the change, committee will announce the change at least 3 days before the change is implemented by feed provider.
+
+# Summary for Shareholders
+This program is simple and effective, and can prevent malicious short-selling or increase malicious short-selling costs to a certain extent.
+
+# Discussion
+https://github.com/bitshares/bsips/issues/244
+
+# See Also
+https://bitsharestalk.org/index.php?topic=29698.0
+https://bitsharestalk.org/index.php?topic=29699.0
+https://bitsharestalk.org/index.php?topic=29635.0
+https://bitsharestalk.org/index.php?topic=28418.0
+https://bitsharestalk.org/index.php?topic=29684.0
+https://bitsharestalk.org/index.php?topic=29687.0
+
+# Copyright
+This document is placed in the public domain.


### PR DESCRIPTION
    BAIP: 0002
    Title: Reform of loopholes in feed price mechanism
    Authors: cn-vote  bitshareschina@163.com
    Status: Draft
    Type: Consensus 
    Created: 2019-11-7


# Abstract
This BAIP defines reforms to the current feed price mechanism vulnerability. The specific program is: The` feed price` is the highest between the `current price` and the ` two-day moving average price` .
# Motivation
After the failure of [BSIP42](https://github.com/bitshares/bsips/blob/master/bsip-0042.md), the current feed price mechanism has major loopholes and serious negatives, many cex exchanges use our vulnerability to maliciously short,which seriously damaged the ecological balance, which caused us to suffer many unnecessary losses and hindered the development of the entire ecology.
When the vulnerability has been expanded to be intolerable, in an emergency, the passage and execution of [BSIP76](https://github.com/bitshares/bsips/blob/master/bsip-0076.md) has temporarily blocked the expansion of the vulnerability. However, the current feed price mechanism is still in urgent need of reform.
# Rational
"The feed price is the highest between the ` current price` and the `two-day moving average price` ".
This BAIP does not conflict with the previous consensus on the feed price of all the communities. The feed provider continue to collect the feed price according to the original community consensus, and the community consensus on the protection of the black swan([BSIP58](https://github.com/bitshares/bsips/blob/master/bsip-0058.md)) and the minimum feed price is continued([BSIP76](https://github.com/bitshares/bsips/blob/master/bsip-0076.md)).
 This BAIP only requires the introduction of the abstract described in the feed price script, which is 
 "The feed price is the highest between the ` current price`  and the ` two-day moving average price` ".
# Specifications
## Implementing measures
```c
If (current price >  two-day moving average price) {
  feed price = current price;
}
Else{
  feed price = two-day moving average price;
}
```


## Noun explanation
* ` Current price ` : The real-time feed price of the current feed price mechanism before the reform.
* ` Two-day moving average price` : ` two-day moving average price`  =(` current price (1)`  + ` current price (2)`  + ` current price ( 3)` ...+` current 
      price (n)` )/n.
    *  n is the `sampling frequency`, which is 48 times, that is, n = 48*m; m is positive: m = 1, 2, 3....
    * `current price (k)` is the current price at the time of sampling. The ` current price (1) ` is the 
        current price at this moment. The ` current price (n) ` is the current price at the time of 48 hours  ago.
    * `Sampling interval` (in hours): `sampling interval` = 48 / n = 48 / (48 * m). That is: m = 1, ` two- 
      day moving average price` every hour to sample once,;m = 2, ` two-day moving average price` half an hour to sample once, And so on.
## supplementary explanation
To decide whether to reform of loopholes in feed price mechanism, 2 poll worker proposals will be created for voting:
* Poll-BAIP**- Reform of loopholes in feed price mechanism.
* Poll-BAIP**-Not reform of loopholes in feed price mechanism.

If the voting confirm the change, committee will announce the change at least 3 days before the change is implemented by feed provider.

# Summary for Shareholders
This program is simple and effective, and can prevent malicious short-selling or increase malicious short-selling costs to a certain extent.

# Discussion
https://github.com/bitshares/bsips/issues/244

# See Also
https://bitsharestalk.org/index.php?topic=29698.0
https://bitsharestalk.org/index.php?topic=29699.0
https://bitsharestalk.org/index.php?topic=29635.0
https://bitsharestalk.org/index.php?topic=28418.0
https://bitsharestalk.org/index.php?topic=29684.0
https://bitsharestalk.org/index.php?topic=29687.0

# Copyright
This document is placed in the public domain.
